### PR TITLE
Active task navigation

### DIFF
--- a/.idea/runConfigurations/AsyncActionNavigationTest.xml
+++ b/.idea/runConfigurations/AsyncActionNavigationTest.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="AsyncActionNavigationTest" type="AndroidJUnit" factoryName="Android JUnit">
+    <module name="assessmentModel" />
+    <useClassPathOnly />
+    <option name="PACKAGE_NAME" value="navigation" />
+    <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.navigation.AsyncActionNavigationTest" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="class" />
+    <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/assessmentModel/src/commonMain/kotlin/navigation/Navigator.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/Navigator.kt
@@ -67,6 +67,10 @@ interface Navigator {
  *
  * The [requestedPermissions] are the permissions to request *before* transitioning to the next node. Typically, these
  * are permissions that are required to run an async action.
+ *
+ * The [asyncActionNavigations] includes a list of async actions to start or stop with this step transition. These
+ * actions are just the configuration. It is up to the view controller or fragment to determine how and if they are
+ * supported.
  */
 data class NavigationPoint(val node: Node?,
                            val branchResult: BranchNodeResult,
@@ -117,7 +121,7 @@ data class AsyncActionNavigation(val sectionIdentifier: String? = null,
 fun Set<AsyncActionNavigation>.union(values: Set<AsyncActionNavigation>): Set<AsyncActionNavigation> {
     val ret = this.toMutableSet()
     values.filter { !it.isEmpty() }.forEach { value ->
-        val existing = this.firstOrNull { it.sectionIdentifier == value.sectionIdentifier }
+        val existing = ret.firstOrNull { it.sectionIdentifier == value.sectionIdentifier }
         if (existing == null) {
             ret.add(value)
         } else {
@@ -127,6 +131,7 @@ fun Set<AsyncActionNavigation>.union(values: Set<AsyncActionNavigation>): Set<As
             val valueStop = value.stopAsyncActions ?: setOf()
             val start = existingStart.plus(valueStart).minus(valueStop)
             val stop = existingStop.plus(valueStop).minus(valueStart)
+            ret.remove(existing)
             ret.add(AsyncActionNavigation(value.sectionIdentifier,
                     if (start.count() > 0) start else null,
                     if (stop.count() > 0) stop else null))

--- a/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
@@ -309,8 +309,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
             //navigationPoint.requestedPermissions = requestedPermissions.plus(navigationPoint.requestedPermissions ?: setOf())
         }
         if (asyncActionNavigations != null) {
-            TODO("syoung 02/05/2020 Add unit test")
-            //navigationPoint.asyncActionNavigations = asyncActionNavigations.union(navigationPoint.asyncActionNavigations ?: setOf())
+            navigationPoint.asyncActionNavigations = asyncActionNavigations.union(navigationPoint.asyncActionNavigations ?: setOf())
         }
     }
 

--- a/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
@@ -305,8 +305,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
                                  requestedPermissions: Set<PermissionInfo>?,
                                  asyncActionNavigations: Set<AsyncActionNavigation>?) {
         if (requestedPermissions != null) {
-            TODO("syoung 02/05/2020 Add unit test")
-            //navigationPoint.requestedPermissions = requestedPermissions.plus(navigationPoint.requestedPermissions ?: setOf())
+            navigationPoint.requestedPermissions = requestedPermissions.plus(navigationPoint.requestedPermissions ?: setOf())
         }
         if (asyncActionNavigations != null) {
             navigationPoint.asyncActionNavigations = asyncActionNavigations.union(navigationPoint.asyncActionNavigations ?: setOf())

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -124,7 +124,7 @@ abstract class IconNodeObject : NodeObject() {
 }
 
 /**
- * TransformableNode
+ * Transformable Nodes
  */
 
 @Serializable

--- a/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
@@ -135,7 +135,7 @@ class AsyncActionNavigationTest : NavigationTestHelper() {
         // There are no permissions to request that are *not* associated with an async action.
         assertNull(point.requestedPermissions)
 
-        val expectedActions = setOf(AsyncActionNavigation("foo", setOf(configA, configC), setOf()))
+        val expectedActions = setOf(AsyncActionNavigation("foo", setOf(configA, configC), null))
         assertEquals(expectedActions, point.asyncActionNavigations)
     }
 

--- a/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
@@ -1,0 +1,180 @@
+package org.sagebionetworks.assessmentmodel.navigation
+
+import org.sagebionetworks.assessmentmodel.PermissionInfo
+import org.sagebionetworks.assessmentmodel.PermissionType
+import org.sagebionetworks.assessmentmodel.RecorderConfiguration
+import org.sagebionetworks.assessmentmodel.serialization.AssessmentObject
+import org.sagebionetworks.assessmentmodel.serialization.PermissionInfoObject
+import kotlin.test.*
+
+class AsyncActionNavigationTest : NavigationTestHelper() {
+
+    data class TestConfig(
+        override val identifier: String,
+        override val startStepIdentifier: String? = null,
+        override val stopStepIdentifier: String? = null,
+        override val permissions: List<PermissionInfo>? = null,
+        override val reason: String? = null,
+        override val optional: Boolean = true,
+        override val resultIdentifier: String? = null,
+        override val comment: String? = null
+    ) : RecorderConfiguration
+
+    /**
+     * AsyncActionNavigation.union
+     */
+
+    @Test
+    fun testAsyncActionNavigation_Union_AddToNullSectionId() {
+        val configA = TestConfig("a")
+        val configB = TestConfig("b")
+        val configC = TestConfig("c")
+        val configD = TestConfig("d")
+
+        val nav1 = setOf(
+            AsyncActionNavigation(null, setOf(configD), null),
+            AsyncActionNavigation("foo", null, setOf(configC)))
+        val nav2 = setOf(
+            AsyncActionNavigation(null, setOf(configA, configB), null))
+        val output1 = nav1.union(nav2)
+        val expected1 = setOf(
+            AsyncActionNavigation(null, setOf(configA, configB, configD), null),
+            AsyncActionNavigation("foo", null, setOf(configC)))
+        assertEquals(expected1, output1)
+    }
+
+    @Test
+    fun testAsyncActionNavigation_Union_AddToFooSectionId() {
+        val configA = TestConfig("a")
+        val configB = TestConfig("b")
+        val configC = TestConfig("c")
+        val configD = TestConfig("d")
+
+        val nav1 = setOf(
+            AsyncActionNavigation(null, setOf(configD), null),
+            AsyncActionNavigation("foo", null, setOf(configC)))
+        val nav2 = setOf(
+            AsyncActionNavigation("foo", setOf(configA, configB), null))
+        val output1 = nav1.union(nav2)
+        val expected1 = setOf(
+            AsyncActionNavigation(null, setOf(configD), null),
+            AsyncActionNavigation("foo", setOf(configA, configB), setOf(configC)))
+        assertEquals(expected1, output1)
+    }
+
+
+    @Test
+    fun testAsyncActionNavigation_Union_Subtract() {
+        val configA = TestConfig("a")
+        val configB = TestConfig("b")
+        val configC = TestConfig("c")
+        val configD = TestConfig("d")
+
+        val nav1 = setOf(
+            AsyncActionNavigation("foo", setOf(configD), setOf(configC)))
+        val nav2 = setOf(
+            AsyncActionNavigation("foo", setOf(configA, configC), setOf(configB)))
+        val output1 = nav1.union(nav2)
+        val expected1 = setOf(
+            AsyncActionNavigation("foo", setOf(configA, configC, configD), setOf(configB)))
+        assertEquals(expected1, output1)
+    }
+
+
+    /**
+     * Start async actions
+     */
+
+    @Test
+    fun testNodeAfter_Node2_FlatLinearNavigation() {
+        val nodeList = buildNodeList(5, 0, "step").toList()
+        val permissions =  listOf(PermissionInfoObject(PermissionType.Standard.Motion))
+        val configA = TestConfig("a")
+        val configB = TestConfig("b", "step3", "step4", permissions)
+        val configC = TestConfig("c", null, "step3")
+        val asyncList = listOf(configA, configB, configC)
+
+        val assessmentObject = AssessmentObject(
+            identifier = "foo",
+            children = nodeList,
+            backgroundActions = asyncList)
+        val navigator = assessmentObject.getNavigator()
+        assertTrue(navigator is NodeNavigator)
+        val result = buildResult(assessmentObject, 2)
+
+        val point = navigator.nodeAfter(nodeList[2], result)
+        assertEquals(nodeList[3], point.node)
+
+        // There are no permissions to request that are *not* associated with an async action.
+        assertNull(point.requestedPermissions)
+
+        val expectedActions = setOf(AsyncActionNavigation("foo", setOf(configB), setOf(configC)))
+        assertEquals(expectedActions, point.asyncActionNavigations)
+    }
+
+    @Test
+    fun testNodeAfter_First_FlatLinearNavigation() {
+        val nodeList = buildNodeList(5, 0, "step").toList()
+        val permissions =  listOf(PermissionInfoObject(PermissionType.Standard.Motion))
+        val configA = TestConfig("a")
+        val configB = TestConfig("b", "step3", "step4", permissions)
+        val configC = TestConfig("c", null, "step3")
+        val asyncList = listOf(configA, configB, configC)
+
+        val assessmentObject = AssessmentObject(
+            identifier = "foo",
+            children = nodeList,
+            backgroundActions = asyncList)
+        val navigator = assessmentObject.getNavigator()
+        assertTrue(navigator is NodeNavigator)
+        val result = assessmentObject.createResult()
+
+        val point = navigator.nodeAfter(null, result)
+        assertEquals(nodeList[0], point.node)
+
+        // There are no permissions to request that are *not* associated with an async action.
+        assertNull(point.requestedPermissions)
+
+        val expectedActions = setOf(AsyncActionNavigation("foo", setOf(configA, configC), setOf()))
+        assertEquals(expectedActions, point.asyncActionNavigations)
+    }
+
+    @Test
+    fun testNodeAfter_Last_FlatLinearNavigation() {
+        val nodeList = buildNodeList(5, 0, "step").toList()
+        val permissions =  listOf(PermissionInfoObject(PermissionType.Standard.Motion))
+        val configA = TestConfig("a")
+        val configB = TestConfig("b", "step3", "step4", permissions)
+        val configC = TestConfig("c", null, "step3")
+        val asyncList = listOf(configA, configB, configC)
+
+        val assessmentObject = AssessmentObject(
+            identifier = "foo",
+            children = nodeList,
+            backgroundActions = asyncList)
+        val navigator = assessmentObject.getNavigator()
+        assertTrue(navigator is NodeNavigator)
+        val result = buildResult(assessmentObject, 4)
+
+        val point = navigator.nodeAfter(nodeList[4], result)
+        assertNull(point.node)
+
+        // There are no permissions to request that are *not* associated with an async action.
+        assertNull(point.requestedPermissions)
+
+        val expectedActions = setOf(AsyncActionNavigation("foo", null, setOf(configA)))
+        assertEquals(expectedActions, point.asyncActionNavigations)
+    }
+}
+
+// Commented out to silence warning. syoung 05/12/2020
+//fun Set<AsyncActionNavigation>.debugPrint() {
+//    val idMap = this.map { async ->
+//        Triple(
+//            async.sectionIdentifier,
+//            async.startAsyncActions?.map { it.identifier },
+//            async.stopAsyncActions?.map { it.identifier }
+//        )
+//    }
+//    println("$idMap")
+//}

--- a/assessmentModel/src/commonTest/kotlin/navigation/SurveyNavigationTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/SurveyNavigationTest.kt
@@ -1,9 +1,7 @@
 package org.sagebionetworks.assessmentmodel.navigation
 
-import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
-import org.sagebionetworks.assessmentmodel.Node
 import org.sagebionetworks.assessmentmodel.serialization.*
 import org.sagebionetworks.assessmentmodel.survey.SurveyRuleOperator
 import org.sagebionetworks.assessmentmodel.survey.compareTo


### PR DESCRIPTION
Added implementation to start/stop async actions.

Note: The bulk of this is handled by the platform including managing the timing of when to request permissions (on iOS this is checked at the start of the Assessment *and* before transitioning to the recording step) and when to start the recorder (on iOS this happens *after* the animation to transition is triggered so as not to block the UI. The view controller is also responsible for tracking the recorders, managing failures, and stopping them if the navigation is reversed. None of that is included in the PR.