### PR TITLE
Add start/end dates to all results

### DIFF
--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -29,6 +29,6 @@ actual object UUIDGenerator {
 }
 
 actual object DateGenerator {
-    actual fun nowString(): String = "TODO: Implement"
+    actual fun nowString(): String = UUID.randomUUID().toString()   // TODO: syoung 06/16/2020 Replace with a timestamp using Android library
     actual fun currentYear(): Int = 2020    // TODO: syoung 02/18/2020 Figure out how to access current year. now() methods are all version >= 26
 }

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -21,6 +21,16 @@ interface Result {
      * [Assessment] element.
      */
     val identifier: String
+
+    /**
+     * The start date timestamp for the result.
+     */
+    var startDateString: String
+
+    /**
+     * The end date timestamp for the result.
+     */
+    var endDateString: String
 }
 
 fun MutableSet<Result>.copyResults() = map { it.copyResult() }.toMutableSet()
@@ -81,16 +91,6 @@ interface AssessmentResult : BranchNodeResult {
      * [Assessment.versionString].
      */
     val versionString: String?
-
-    /**
-     * The start date timestamp for the result.
-     */
-    var startDateString: String
-
-    /**
-     * The end date timestamp for the result.
-     */
-    var endDateString: String
 }
 
 /**

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -30,7 +30,7 @@ interface Result {
     /**
      * The end date timestamp for the result.
      */
-    var endDateString: String
+    var endDateString: String?
 }
 
 fun MutableSet<Result>.copyResults() = map { it.copyResult() }.toMutableSet()

--- a/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
@@ -196,6 +196,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
                                 asyncActionNavigations: Set<AsyncActionNavigation>?) {
         val next = getNextNode(direction) ?: return
         unionNavigationSets(next, requestedPermissions, asyncActionNavigations)
+        currentChild?.currentResult?.endDateString = DateGenerator.nowString()
         if (next.node != null) {
             // Go to next node if it is not null.
             moveTo(next)
@@ -213,6 +214,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
         val controller = rootNodeController ?: throw NullPointerException("Unexpected null rootNodeController")
         val node = navigationPoint.node ?: throw NullPointerException("Unexpected null navigationPoint.node")
         val pathMarker = PathMarker(node.identifier, navigationPoint.direction)
+        // Update the current result and current child end date.
         if (currentResult.path.lastOrNull() != pathMarker) {
             currentResult.path.add(pathMarker)
         }
@@ -221,6 +223,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
             // child and hand off control to the root node controller.
             getLeafNodeState(navigationPoint)?.let { nodeState ->
                 currentChild = nodeState
+                nodeState.currentResult.startDateString = DateGenerator.nowString()
                 if (navigationPoint.direction == NavigationPoint.Direction.Forward) {
                     controller.handleGoForward(nodeState, navigationPoint.requestedPermissions, navigationPoint.asyncActionNavigations)
                 } else {
@@ -245,6 +248,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
      * exiting the entire run or just that this section is finished.
      */
     open fun finish(navigationPoint: NavigationPoint) {
+        currentResult.endDateString = DateGenerator.nowString()
         when {
             navigationPoint.direction == NavigationPoint.Direction.Exit ->
                 exitEarly(navigationPoint.asyncActionNavigations)

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -27,7 +27,7 @@ data class AnswerResultObject(override val identifier: String,
                               @SerialName("startDate")
                               override var startDateString: String = DateGenerator.nowString(),
                               @SerialName("endDate")
-                              override var endDateString: String = DateGenerator.nowString()) : AnswerResult {
+                              override var endDateString: String? = null) : AnswerResult {
     override fun copyResult(identifier: String): AnswerResult = this.copy(identifier = identifier)
 }
 
@@ -44,7 +44,7 @@ data class AssessmentResultObject(override val identifier: String,
                                   @SerialName("startDate")
                                   override var startDateString: String = DateGenerator.nowString(),
                                   @SerialName("endDate")
-                                  override var endDateString: String = DateGenerator.nowString(),
+                                  override var endDateString: String? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null)
@@ -61,7 +61,7 @@ data class ResultObject(override val identifier: String,
                         @SerialName("startDate")
                         override var startDateString: String = DateGenerator.nowString(),
                         @SerialName("endDate")
-                        override var endDateString: String = DateGenerator.nowString(),
+                        override var endDateString: String? = null,
                         @SerialName("skipToIdentifier")
                         override var nextNodeIdentifier: String? = null) : Result, ResultNavigationRule {
     override fun copyResult(identifier: String): Result = this.copy(identifier = identifier)
@@ -74,7 +74,7 @@ data class CollectionResultObject(override val identifier: String,
                                   @SerialName("startDate")
                                   override var startDateString: String = DateGenerator.nowString(),
                                   @SerialName("endDate")
-                                  override var endDateString: String = DateGenerator.nowString(),
+                                  override var endDateString: String? = null,
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : CollectionResult, ResultNavigationRule {
     override fun copyResult(identifier: String): CollectionResult = this.copy(
@@ -92,7 +92,7 @@ data class BranchNodeResultObject(override val identifier: String,
                                   @SerialName("startDate")
                                   override var startDateString: String = DateGenerator.nowString(),
                                   @SerialName("endDate")
-                                  override var endDateString: String = DateGenerator.nowString(),
+                                  override var endDateString: String? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : BranchNodeResult, ResultNavigationRule {

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -23,7 +23,11 @@ val resultSerializersModule = SerializersModule {
 data class AnswerResultObject(override val identifier: String,
                               override var answerType: AnswerType? = null,
                               @SerialName("value")
-                              override var jsonValue: JsonElement? = null) : AnswerResult {
+                              override var jsonValue: JsonElement? = null,
+                              @SerialName("startDate")
+                              override var startDateString: String = DateGenerator.nowString(),
+                              @SerialName("endDate")
+                              override var endDateString: String = DateGenerator.nowString()) : AnswerResult {
     override fun copyResult(identifier: String): AnswerResult = this.copy(identifier = identifier)
 }
 
@@ -54,6 +58,10 @@ data class AssessmentResultObject(override val identifier: String,
 @Serializable
 @SerialName("base")
 data class ResultObject(override val identifier: String,
+                        @SerialName("startDate")
+                        override var startDateString: String = DateGenerator.nowString(),
+                        @SerialName("endDate")
+                        override var endDateString: String = DateGenerator.nowString(),
                         @SerialName("skipToIdentifier")
                         override var nextNodeIdentifier: String? = null) : Result, ResultNavigationRule {
     override fun copyResult(identifier: String): Result = this.copy(identifier = identifier)
@@ -63,6 +71,10 @@ data class ResultObject(override val identifier: String,
 @SerialName("collection")
 data class CollectionResultObject(override val identifier: String,
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
+                                  @SerialName("startDate")
+                                  override var startDateString: String = DateGenerator.nowString(),
+                                  @SerialName("endDate")
+                                  override var endDateString: String = DateGenerator.nowString(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : CollectionResult, ResultNavigationRule {
     override fun copyResult(identifier: String): CollectionResult = this.copy(
@@ -71,12 +83,16 @@ data class CollectionResultObject(override val identifier: String,
 }
 
 @Serializable
-@SerialName("task")
+@SerialName("section")
 data class BranchNodeResultObject(override val identifier: String,
                                   @SerialName("stepHistory")
                                   override var pathHistoryResults: MutableList<Result> = mutableListOf(),
                                   @SerialName("asyncResults")
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
+                                  @SerialName("startDate")
+                                  override var startDateString: String = DateGenerator.nowString(),
+                                  @SerialName("endDate")
+                                  override var endDateString: String = DateGenerator.nowString(),
                                   override val path: MutableList<PathMarker> = mutableListOf(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : BranchNodeResult, ResultNavigationRule {

--- a/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
@@ -767,8 +767,8 @@ class NodeNavigatorTest : NavigationTestHelper() {
         // The expected behavior is that the step result should only be included *once*.
         nodeState.goForward()
 
-        val expectedPathResults = listOf<Result>(testResult)
-        assertEquals(expectedPathResults, nodeState.currentResult.pathHistoryResults)
+        val actualPath = nodeState.currentResult.pathHistoryResults.map { it.identifier }
+        assertEquals(listOf("step1"), actualPath)
     }
 
     @Test
@@ -778,12 +778,11 @@ class NodeNavigatorTest : NavigationTestHelper() {
         val nodeState = BranchNodeStateImpl(assessmentObject)
         nodeState.rootNodeController = rootNodeController
         nodeState.goForward()
-        val testResult = ResultObject("step1")
         // The expected behavior is that the step result should be added.
         nodeState.goForward()
 
-        val expectedPathResults = listOf<Result>(testResult)
-        assertEquals(expectedPathResults, nodeState.currentResult.pathHistoryResults)
+        val actualPath = nodeState.currentResult.pathHistoryResults.map { it.identifier }
+        assertEquals(listOf("step1"), actualPath)
     }
 }
 
@@ -793,7 +792,16 @@ open class NavigationTestHelper {
      * Helper methods
      */
 
-    data class TestResult(override val identifier: String, val answer: String) : Result {
+    data class TestResult(override val identifier: String,
+                          val answer: String
+    ) : Result {
+
+        // TODO: syoung 06/16/2020 Once timestamp generation is implemented for Android (which is the platform used for test)
+        // then add checks that the dates are being updated properly to mark begin/end of steps.
+
+        override var startDateString: String = DateGenerator.nowString()
+        override var endDateString: String = DateGenerator.nowString()
+
         override fun copyResult(identifier: String): Result = copy(identifier = identifier)
     }
 

--- a/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
@@ -800,7 +800,7 @@ open class NavigationTestHelper {
         // then add checks that the dates are being updated properly to mark begin/end of steps.
 
         override var startDateString: String = DateGenerator.nowString()
-        override var endDateString: String = DateGenerator.nowString()
+        override var endDateString: String? = null
 
         override fun copyResult(identifier: String): Result = copy(identifier = identifier)
     }

--- a/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
@@ -26,31 +26,62 @@ open class ResultTest {
     @UnstableDefault
     @Test
     fun testParentNodeResult() {
-        val result1 = ResultObject("result1")
-        val result2 = ResultObject("result2")
-        val result3 = BranchNodeResultObject(identifier = "result3",
-                pathHistoryResults = mutableListOf(ResultObject("resultA"), ResultObject("resultB")),
-                inputResults = mutableSetOf(ResultObject("asyncResultA"), ResultObject("asyncResultB")))
-        val result4 = CollectionResultObject(identifier = "result4",
-                inputResults = mutableSetOf(ResultObject("asyncResultA"), ResultObject("asyncResultB")))
-
-        val original = BranchNodeResultObject("testResult", pathHistoryResults = mutableListOf(result1, result2, result3, result4))
+        val result1 = ResultObject("result1", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val result2 = ResultObject("result2", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val resultA = ResultObject("resultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val resultB = ResultObject("resultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val asyncResultA = ResultObject("asyncResultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val asyncResultB = ResultObject("asyncResultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val result3 = BranchNodeResultObject(
+            identifier = "result3",
+            pathHistoryResults = mutableListOf(resultA, resultB),
+            inputResults = mutableSetOf(asyncResultA, asyncResultB),
+            startDateString = "2020-01-21T12:00:00.000+7000",
+            endDateString = "2020-01-21T12:05:00.000+7000"
+        )
+        val result4 = CollectionResultObject(
+            identifier = "result4",
+            inputResults = mutableSetOf(asyncResultA, asyncResultB),
+            startDateString = "2020-01-21T12:00:00.000+7000",
+            endDateString = "2020-01-21T12:05:00.000+7000"
+        )
+        val original = BranchNodeResultObject(
+            identifier = "testResult",
+            pathHistoryResults = mutableListOf(result1, result2, result3, result4),
+            startDateString = "2020-01-21T12:00:00.000+7000",
+            endDateString = "2020-01-21T12:05:00.000+7000"
+        )
         val inputString = """
             {
                 "identifier": "testResult",
+                "startDate": "2020-01-21T12:00:00.000+7000",
+                "endDate": "2020-01-21T12:05:00.000+7000",
                 "stepHistory": [
-                    {"identifier": "result1","type": "base"},
-                    {"identifier": "result2","type": "base"},
+                    {"identifier": "result1","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                    {"identifier": "result2","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
                     {
                         "identifier": "result3",
-                        "type": "task",
-                        "stepHistory": [{"identifier": "resultA","type": "base"},{"identifier": "resultB","type": "base"}],
-                        "asyncResults": [{"identifier": "asyncResultA","type": "base"},{"identifier": "asyncResultB","type": "base"}]
+                        "type": "section",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "stepHistory": [
+                            {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                            {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                        ],
+                        "asyncResults": [
+                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                        ]
                     },
                     {
                         "identifier": "result4",
                         "type": "collection",
-                        "inputResults": [{"identifier": "asyncResultA","type": "base"},{"identifier": "asyncResultB","type": "base"}]
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "inputResults": [
+                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                        ]
                     }
                 ]
             }   
@@ -82,9 +113,14 @@ open class ResultTest {
     @UnstableDefault
     @Test
     fun testAssessmentResult() {
+        val resultA = ResultObject("resultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val resultB = ResultObject("resultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val asyncResultA = ResultObject("asyncResultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val asyncResultB = ResultObject("asyncResultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+
         val original = AssessmentResultObject(identifier = "testResult",
-                pathHistoryResults = mutableListOf(ResultObject("resultA"), ResultObject("resultB")),
-                inputResults = mutableSetOf(ResultObject("asyncResultA"), ResultObject("asyncResultB")),
+                pathHistoryResults = mutableListOf(resultA, resultB),
+                inputResults = mutableSetOf(asyncResultA, asyncResultB),
                 runUUIDString = "4cb0580-3cdb-11ea-b77f-2e728ce88125",
                 startDateString = "2020-01-21T12:00:00.000+7000",
                 endDateString = "2020-01-21T12:05:00.000+7000"
@@ -95,8 +131,14 @@ open class ResultTest {
                 "taskRunUUID": "4cb0580-3cdb-11ea-b77f-2e728ce88125",
                 "startDate": "2020-01-21T12:00:00.000+7000",
                 "endDate": "2020-01-21T12:05:00.000+7000",
-                "stepHistory": [{"identifier": "resultA","type": "base"},{"identifier": "resultB","type": "base"}],
-                "asyncResults": [{"identifier": "asyncResultA","type": "base"},{"identifier": "asyncResultB","type": "base"}]
+                "stepHistory": [
+                    {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                    {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                ],
+                "asyncResults": [
+                    {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                    {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                ]
             }
             """.trimIndent()
 
@@ -158,12 +200,15 @@ open class ResultTest {
 
     @Test
     fun testAnswerResult_Boolean() {
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.BOOLEAN, JsonPrimitive(true)))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.BOOLEAN, JsonPrimitive(true), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
             { "result": 
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "boolean"
                         },
@@ -184,12 +229,15 @@ open class ResultTest {
 
     @Test
     fun testAnswerResult_Decimal() {
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.DECIMAL, JsonPrimitive(3.2)))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.DECIMAL, JsonPrimitive(3.2), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "number"
                         },
@@ -210,12 +258,15 @@ open class ResultTest {
 
     @Test
     fun testAnswerResult_Int() {
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.INTEGER, JsonPrimitive(3)))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.INTEGER, JsonPrimitive(3), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
             { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "integer"
                         },
@@ -237,12 +288,15 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Map() {
         val originalValue = JsonObject(mapOf("a" to JsonLiteral(3.2), "b" to JsonLiteral("boo")))
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.OBJECT, originalValue))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.OBJECT, originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "object"
                         },
@@ -264,12 +318,15 @@ open class ResultTest {
     @Test
     fun testAnswerResult_String() {
         val originalValue = JsonPrimitive("goo")
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.STRING, originalValue))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.STRING, originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "string"
                         },
@@ -291,12 +348,15 @@ open class ResultTest {
     @Test
     fun testAnswerResult_DateYearMonth() {
         val originalValue = JsonPrimitive("2020-02")
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.DateTime("yyyy-MM"), originalValue))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.DateTime("yyyy-MM"), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "dateTime",
                             "codingFormat": "yyyy-MM"
@@ -319,12 +379,15 @@ open class ResultTest {
     @Test
     fun testAnswerResult_ListInt() {
         val originalValue = JsonArray(listOf(JsonPrimitive(2), JsonPrimitive(5)))
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.Array(BaseType.INTEGER), originalValue))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.Array(BaseType.INTEGER), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "array",
                             "baseType": "integer"
@@ -347,12 +410,15 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Measurement() {
         val originalValue = JsonPrimitive(10.2)
-        val original = TestResultWrapper(AnswerResultObject("foo", AnswerType.Measurement("cm"), originalValue))
+        val original = TestResultWrapper(
+            AnswerResultObject("foo", AnswerType.Measurement("cm"), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
+                        "startDate": "2020-01-21T12:00:00.000+7000",
+                        "endDate": "2020-01-21T12:05:00.000+7000",
                         "answerType" : {
                             "type": "measurement",
                             "unit": "cm"
@@ -376,11 +442,6 @@ open class ResultTest {
      * Result - copyResult
      */
 
-//    AnswerResultObject::class with AnswerResultObject.serializer()
-//    AssessmentResultObject::class with AssessmentResultObject.serializer()
-//    BranchNodeResultObject::class with BranchNodeResultObject.serializer()
-//    CollectionResultObject::class with CollectionResultObject.serializer()
-//    ResultObject::class with ResultObject.serializer()
     @Test
     fun testResultObject_copyResult() {
         val original = ResultObject("foo")


### PR DESCRIPTION
The research team would like to be able to see timestamps for the start and end
for each step.

Note: By default, the timestamp is *not* a precision time marker. The timestamp
is marked to an approximate timing and is set to *before* any animations will be
performed.

This does *not* include updating the frameworks to include support for actual timestamps on Android. (Somewhat ironically, it will work correctly for iOS)

Additionally, this does not include all the metadata stuff that we are currently including in the archive. Just adding the start/end date to all results.