### PR TITLE
Update and refactor result keys

### DIFF
--- a/assessmentModel/src/commonMain/kotlin/Assessment.kt
+++ b/assessmentModel/src/commonMain/kotlin/Assessment.kt
@@ -43,8 +43,11 @@ interface Assessment : BranchNode, ContentNode {
     val estimatedMinutes: Int
 
     // Override the default implementation to return an [AssessmentResult]
-    override fun createResult(): AssessmentResult
-            = AssessmentResultObject(resultId(), versionString)
+    override fun createResult(): AssessmentResult = AssessmentResultObject(
+        identifier = resultId(),
+        assessmentIdentifier = identifier,
+        schemaIdentifier = resultId(),
+        versionString = versionString)
 
     override fun unpack(fileLoader: FileLoader, resourceInfo: ResourceInfo, jsonCoder: Json): Assessment
 }

--- a/assessmentModel/src/commonMain/kotlin/Assessment.kt
+++ b/assessmentModel/src/commonMain/kotlin/Assessment.kt
@@ -36,6 +36,12 @@ interface Assessment : BranchNode, ContentNode {
     val versionString: String?
 
     /**
+     * The [schemaIdentifier] is used to allow a group of [Assessment] models to all map to the same
+     * table in a data base.
+     */
+    val schemaIdentifier: String?
+
+    /**
      * The estimated number of minutes that the assessment will take. If `0`, then it is assumed that this value is not
      * defined. Where provided, it can be used by an application to indicate to the participant approximately how
      * long an assessment is expected to take to complete.
@@ -46,7 +52,7 @@ interface Assessment : BranchNode, ContentNode {
     override fun createResult(): AssessmentResult = AssessmentResultObject(
         identifier = resultId(),
         assessmentIdentifier = identifier,
-        schemaIdentifier = resultId(),
+        schemaIdentifier = schemaIdentifier,
         versionString = versionString)
 
     override fun unpack(fileLoader: FileLoader, resourceInfo: ResourceInfo, jsonCoder: Json): Assessment
@@ -56,9 +62,6 @@ interface Assessment : BranchNode, ContentNode {
  * A result map element is an element in the [Assessment] model that defines the expectations for a [Result] associated
  * with this element. It can define a user-facing step, a section (which may or may not map to a view), a background
  * web service, a sensor recorder, or any other piece of data collected by the overall [Assessment].
- *
- * The [identifier] is used to build the input model mapping and the [resultIdentifier] is used to build an output model
- * with the same hierarchy where all the elements of the model conform to the [Result] protocol.
  */
 interface ResultMapElement {
 
@@ -66,12 +69,6 @@ interface ResultMapElement {
      * The identifier for the node.
      */
     val identifier: String
-
-    /**
-     * The identifier to use for the [Result] (if any) associated with this node. If null, the [identifier] will be
-     * used instead.
-     */
-    val resultIdentifier: String?
 
     /**
      * The [comment] is *not* intended to be user-facing and is a field that allows the [Assessment] designer to add
@@ -88,7 +85,7 @@ interface ResultMapElement {
 /**
  * Convenience method for accessing the result identifier associated with a given node.
  */
-fun ResultMapElement.resultId() : String = resultIdentifier ?: identifier
+fun ResultMapElement.resultId() : String = identifier
 
 /**
  * A [Node] is any object defined within the structure of an [Assessment] that is used to display a sequence of [Step]

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -87,7 +87,7 @@ interface AssessmentResult : BranchNodeResult {
     var runUUIDString: String
 
     /**
-     * A unique identifier for a [Assessment] model associated with this result. This is explicitly
+     * A unique identifier for an [Assessment] model associated with this result. This is explicitly
      * included so that the [identifier] can be associated as per the needs of the developers and
      * to allow for changes to the API that are not important to the researcher.
      */

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -87,6 +87,20 @@ interface AssessmentResult : BranchNodeResult {
     var runUUIDString: String
 
     /**
+     * A unique identifier for a [Assessment] model associated with this result. This is explicitly
+     * included so that the [identifier] can be associated as per the needs of the developers and
+     * to allow for changes to the API that are not important to the researcher.
+     */
+    val assessmentIdentifier: String?
+
+    /**
+     * A unique identifier for a schema associated with this result. This is explicitly included so
+     * that the [identifier] can be associated as per the needs of the developers and to allow for
+     * changes to the API that are not important to the researcher.
+     */
+    val schemaIdentifier: String?
+
+    /**
      * The [versionString] may be a semantic version, timestamp, or sequential revision integer. This should map to the
      * [Assessment.versionString].
      */

--- a/assessmentModel/src/commonMain/kotlin/recorders/DistanceRecorderConfiguration.kt
+++ b/assessmentModel/src/commonMain/kotlin/recorders/DistanceRecorderConfiguration.kt
@@ -19,7 +19,6 @@ import org.sagebionetworks.assessmentmodel.*
 @SerialName("distance")
 data class DistanceRecorderConfiguration(
     override val identifier: String,
-    override val resultIdentifier: String? = null,
     @SerialName("description")
     override val comment: String? = null,
     override val reason: String? = null,

--- a/assessmentModel/src/commonMain/kotlin/recorders/MotionRecorderConfiguration.kt
+++ b/assessmentModel/src/commonMain/kotlin/recorders/MotionRecorderConfiguration.kt
@@ -11,7 +11,6 @@ import org.sagebionetworks.assessmentmodel.*
 @SerialName("motion")
 data class MotionRecorderConfiguration(
     override val identifier: String,
-    override val resultIdentifier: String? = null,
     @SerialName("description")
     override val comment: String? = null,
     override val reason: String? = null,

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -132,8 +132,7 @@ abstract class IconNodeObject : NodeObject() {
 data class TransformableNodeObject(
     override val identifier: String,
     override val resourceName: String,
-    override val versionString: String? = null,
-    override val resultIdentifier: String? = null
+    override val versionString: String? = null
 ) : IconNodeObject(), TransformableNode
 
 @Serializable
@@ -143,7 +142,7 @@ data class TransformableAssessmentObject(
     override val resourceName: String,
     override val versionString: String? = null,
     override val estimatedMinutes: Int = 0,
-    override val resultIdentifier: String? = null
+    override val schemaIdentifier: String? = null
 ) : IconNodeObject(), TransformableAssessment
 
 /**
@@ -169,7 +168,7 @@ data class AssessmentObject(
     @SerialName("steps")
     override val children: List<Node>,
     override val versionString: String? = null,
-    override val resultIdentifier: String? = null,
+    override val schemaIdentifier: String? = null,
     override var estimatedMinutes: Int = 0,
     @SerialName("asyncActions")
     override val backgroundActions: List<AsyncActionConfiguration> = listOf()
@@ -190,7 +189,6 @@ data class SectionObject(
     override val identifier: String,
     @SerialName("steps")
     override val children: List<Node>,
-    override val resultIdentifier: String? = null,
     @SerialName("asyncActions")
     override val backgroundActions: List<AsyncActionConfiguration> = listOf()
 ) : NodeContainerObject(), Section, AsyncActionContainer {
@@ -211,7 +209,6 @@ data class SectionObject(
 @SerialName("instruction")
 data class InstructionStepObject(
     override val identifier: String,
-     override val resultIdentifier: String? = null,
      @SerialName("image")
      override var imageInfo: ImageInfo? = null,
      override var fullInstructionsOnly: Boolean = false
@@ -224,8 +221,7 @@ data class OverviewStepObject(
     @SerialName("image")
     override var imageInfo: ImageInfo? = null,
     override var icons: List<IconInfoObject>? = null,
-    override var permissions: List<PermissionInfoObject>? = null,
-    override val resultIdentifier: String? = null
+    override var permissions: List<PermissionInfoObject>? = null
 ) : StepObject(), OverviewStep {
     override var learnMore: ButtonActionInfo?
         get() = buttonMap[ButtonAction.Navigation.LearnMore]
@@ -249,8 +245,7 @@ data class ResultSummaryStepObject(
     override val scoringResultPath: IdentifierPath? = null,
     override var resultTitle: String? = null,
     @SerialName("image")
-    override var imageInfo: ImageInfo? = null,
-    override val resultIdentifier: String? = null
+    override var imageInfo: ImageInfo? = null
 ) : StepObject(), ResultSummaryStep
 
 /**
@@ -261,7 +256,6 @@ data class ResultSummaryStepObject(
 @SerialName("form")
 data class FormStepObject(
     override val identifier: String,
-    override val resultIdentifier: String? = null,
     @SerialName("image")
     override val imageInfo: ImageInfo? = null,
     // TODO: syoung 04/22/2020 iOS defines the child nodes as "inputFields" but may want to change that?
@@ -295,7 +289,6 @@ abstract class QuestionObject : StepObject(), Question, SurveyNavigationRule {
 data class SimpleQuestionObject(
     override val identifier: String,
     override val inputItem: InputItem,
-    override val resultIdentifier: String? = null,
     override var skipCheckbox: SkipCheckboxInputItem? = null
 ) : QuestionObject(), SimpleQuestion
 
@@ -304,7 +297,6 @@ data class SimpleQuestionObject(
 data class MultipleInputQuestionObject(
     override val identifier: String,
     override val inputItems: List<InputItem>,
-    override val resultIdentifier: String? = null,
     override var sequenceSeparator: String? = null,
     override var skipCheckbox: SkipCheckboxInputItem? = null
 ) : QuestionObject(), MultipleInputQuestion
@@ -315,7 +307,6 @@ data class ChoiceQuestionObject(
     override val identifier: String,
     override val choices: List<ChoiceOptionObject>,
     override val baseType: BaseType = BaseType.STRING,
-    override val resultIdentifier: String? = null,
     @SerialName("singleChoice")
     override var singleAnswer: Boolean = true,
     override var uiHint: UIHint = UIHint.Choice.ListItem
@@ -327,7 +318,6 @@ data class StringChoiceQuestionObject(
     override val identifier: String,
     @SerialName("choices")
     val items: List<String>,
-    override val resultIdentifier: String? = null,
     @SerialName("singleChoice")
     override var singleAnswer: Boolean = true,
     override var uiHint: UIHint = UIHint.Choice.ListItem
@@ -344,7 +334,6 @@ data class ComboBoxQuestionObject(
     override val identifier: String,
     override val choices: List<ChoiceOptionObject>,
     override val otherInputItem: InputItem = defaultOtherInputItem,
-    override val resultIdentifier: String? = null,
     @SerialName("singleChoice")
     override var singleAnswer: Boolean = false,
     override var uiHint: UIHint = UIHint.Choice.Checkbox
@@ -399,8 +388,7 @@ abstract class BaseActiveStepObject : StepObject(), ActiveStep {
 @SerialName("active")
 data class ActiveStepObject(
     override val identifier: String,
-    override val duration: Double,
-    override val resultIdentifier: String? = null
+    override val duration: Double
 ) : BaseActiveStepObject()
 
 // CountdownStepObject will have a default timer of 5 seconds,
@@ -410,7 +398,6 @@ data class ActiveStepObject(
 data class CountdownStepObject(
     override val identifier: String,
     override val duration: Double = 5.0,
-    override val resultIdentifier: String? = null,
     override val fullInstructionsOnly: Boolean = false
 ) : BaseActiveStepObject(), CountdownStep {
     override var commands: Set<ActiveStepCommand>

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -34,6 +34,8 @@ data class AnswerResultObject(override val identifier: String,
 @Serializable
 @SerialName("assessment")
 data class AssessmentResultObject(override val identifier: String,
+                                  override val assessmentIdentifier: String? = null,
+                                  override val schemaIdentifier: String? = null,
                                   override val versionString: String? = null,
                                   @SerialName("stepHistory")
                                   override var pathHistoryResults: MutableList<Result> = mutableListOf(),

--- a/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/AsyncActionNavigationTest.kt
@@ -16,7 +16,6 @@ class AsyncActionNavigationTest : NavigationTestHelper() {
         override val permissions: List<PermissionInfo>? = null,
         override val reason: String? = null,
         override val optional: Boolean = true,
-        override val resultIdentifier: String? = null,
         override val comment: String? = null
     ) : RecorderConfiguration
 

--- a/assessmentModel/src/commonTest/kotlin/serialization/AsyncActionTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/AsyncActionTest.kt
@@ -21,7 +21,6 @@ open class AsyncActionTest {
     fun testDistanceRecorderConfiguration_Serialization() {
         val config = DistanceRecorderConfiguration(
             identifier = "foo",
-            resultIdentifier = "bar",
             motionStepIdentifier = "magoo",
             startStepIdentifier = "baloo",
             stopStepIdentifier = "too",
@@ -33,7 +32,6 @@ open class AsyncActionTest {
                 "config": {
                     "type": "distance",
                     "identifier": "foo",
-                    "resultIdentifier": "bar",
                     "startStepIdentifier": "baloo",
                     "stopStepIdentifier": "too",
                     "motionStepIdentifier": "magoo",
@@ -107,7 +105,6 @@ open class AsyncActionTest {
     fun testMotionRecorderConfiguration_Serialization() {
         val config = MotionRecorderConfiguration(
             identifier = "foo",
-            resultIdentifier = "bar",
             startStepIdentifier = "baloo",
             stopStepIdentifier = "too",
             requiresBackground = true,
@@ -121,7 +118,6 @@ open class AsyncActionTest {
                 "config": {
                     "type": "motion",
                     "identifier": "foo",
-                    "resultIdentifier": "bar",
                     "startStepIdentifier": "baloo",
                     "stopStepIdentifier": "too",
                     "requiresBackgroundAudio": true,

--- a/assessmentModel/src/commonTest/kotlin/serialization/NodeTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/NodeTest.kt
@@ -128,7 +128,6 @@ open class NodeTest : NodeSerializationTestHelper() {
                 "type": "assessment",
                 "identifier": "foo",
                 "versionString": "1.2.3",
-                "resultIdentifier":"bar",
                 "title": "Hello World!",
                 "subtitle": "Subtitle",
                 "detail": "Some text. This is a test.",
@@ -163,7 +162,6 @@ open class NodeTest : NodeSerializationTestHelper() {
 
         val original = AssessmentObject(
                 identifier = "foo",
-                resultIdentifier = "bar",
                 versionString = "1.2.3",
                 children = listOf(
                         buildInstructionStep("step1", "Step 1"),
@@ -200,7 +198,7 @@ open class NodeTest : NodeSerializationTestHelper() {
     }
 
     @Test
-    fun testAssessment_Result_NullResultId() {
+    fun testAssessment_Result() {
         val original = AssessmentObject(
                 identifier = "foo",
                 children = listOf(
@@ -208,18 +206,6 @@ open class NodeTest : NodeSerializationTestHelper() {
                         buildInstructionStep("step2", "Step 2")))
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-    }
-
-    @Test
-    fun testAssessment_Result_WithResultId() {
-        val original = AssessmentObject(
-                identifier = "foo",
-                resultIdentifier = "bar",
-                children = listOf(
-                        buildInstructionStep("step1", "Step 1"),
-                        buildInstructionStep("step2", "Step 2")))
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
     }
 
     /**
@@ -361,7 +347,7 @@ open class NodeTest : NodeSerializationTestHelper() {
     fun testCountdownStep_DefaultParams() {
         // Check default situation that duration = 5.0, and
         // commands contains auto transition.
-        val original = CountdownStepObject("foo", resultIdentifier = "bar", fullInstructionsOnly = true)
+        val original = CountdownStepObject("foo", fullInstructionsOnly = true)
         original.title = "Hello World!"
 
         assertEquals(5.0, original.duration)
@@ -382,7 +368,6 @@ open class NodeTest : NodeSerializationTestHelper() {
         val inputString = """
            {
                "identifier": "foo",
-               "resultIdentifier": "bar",
                "type": "countdown",
                "fullInstructionsOnly": true,
                "title": "Hello World!",
@@ -403,7 +388,7 @@ open class NodeTest : NodeSerializationTestHelper() {
                                "animationDuration" : 2}
             }
            """
-        val original = CountdownStepObject("foo", 30.0, "bar", true)
+        val original = CountdownStepObject("foo", 30.0, true)
         original.title = "Hello World!"
         original.spokenInstructions = mapOf(
             SpokenInstructionTiming.Keyword.Start to "Start moving",
@@ -586,17 +571,10 @@ open class NodeTest : NodeSerializationTestHelper() {
     }
 
     @Test
-    fun testInstructionStep_Result_NullResultId() {
+    fun testInstructionStep_Result() {
         val original = InstructionStepObject("foo")
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-    }
-
-    @Test
-    fun testInstructionStep_Result_WithResultId() {
-        val original = InstructionStepObject("foo", resultIdentifier = "bar")
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
     }
 
     /**
@@ -948,7 +926,7 @@ open class NodeTest : NodeSerializationTestHelper() {
     }
 
     @Test
-    fun testSection_Result_NullResultId() {
+    fun testSection_Result() {
         val original = SectionObject(
                 identifier = "foo",
                 children = listOf(
@@ -956,18 +934,6 @@ open class NodeTest : NodeSerializationTestHelper() {
                         buildInstructionStep("step2", "Step 2")))
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-    }
-
-    @Test
-    fun testSection_Result_WithResultId() {
-        val original = SectionObject(
-                identifier = "foo",
-                resultIdentifier = "bar",
-                children = listOf(
-                        buildInstructionStep("step1", "Step 1"),
-                        buildInstructionStep("step2", "Step 2")))
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
     }
 
     /**
@@ -1209,7 +1175,6 @@ open class NodeTest : NodeSerializationTestHelper() {
                 "type": "assessment",
                 "identifier": "foo",
                 "versionString": "1.2.3",
-                "resultIdentifier":"bar",
                 "title": "Hello World!",
                 "subtitle": "Subtitle",
                 "icon": "fooIcon",
@@ -1240,7 +1205,6 @@ open class NodeTest : NodeSerializationTestHelper() {
 
         val original = AssessmentObject(
                 identifier = "foo",
-                resultIdentifier = "bar",
                 versionString = "1.2.3",
                 children = listOf(
                         originalStep1,
@@ -1281,7 +1245,6 @@ open class NodeSerializationTestHelper {
 
     fun assertEqualResultMapElement(expected: ResultMapElement, actual: ResultMapElement) {
         assertEquals(expected.identifier, actual.identifier)
-        assertEquals(expected.resultIdentifier, actual.resultIdentifier)
         assertEquals(expected.comment, actual.comment)
     }
 

--- a/assessmentModel/src/commonTest/kotlin/survey/QuestionTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/survey/QuestionTest.kt
@@ -16,18 +16,10 @@ class QuestionTest : NavigationTestHelper() {
      */
 
     @Test
-    fun testChoiceQuestion_Result_NullResultId() {
+    fun testChoiceQuestion_Result() {
         val original = ChoiceQuestionObject("foo", listOf())
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-        assertEquals(original.answerType, result.answerType)
-    }
-
-    @Test
-    fun testChoiceQuestion_Result_WithResultId() {
-        val original = ChoiceQuestionObject("foo", listOf(), resultIdentifier = "bar")
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
         assertEquals(original.answerType, result.answerType)
     }
 
@@ -80,18 +72,10 @@ class QuestionTest : NavigationTestHelper() {
      */
 
     @Test
-    fun testComboBoxQuestion_Result_NullResultId() {
+    fun testComboBoxQuestion_Result() {
         val original = ComboBoxQuestionObject("foo", listOf())
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-        assertEquals(original.answerType, result.answerType)
-    }
-
-    @Test
-    fun testComboBoxQuestion_Result_WithResultId() {
-        val original = ComboBoxQuestionObject("foo", listOf(), resultIdentifier = "bar")
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
         assertEquals(original.answerType, result.answerType)
     }
 
@@ -145,18 +129,10 @@ class QuestionTest : NavigationTestHelper() {
      */
 
     @Test
-    fun testMultipleInputQuestion_Result_NullResultId() {
+    fun testMultipleInputQuestion_Result() {
         val original = MultipleInputQuestionObject("foo", inputItems = listOf(StringTextInputItemObject(), StringTextInputItemObject()))
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-        assertEquals(original.answerType, result.answerType)
-    }
-
-    @Test
-    fun testMultipleInputQuestion_Result_WithResultId() {
-        val original = MultipleInputQuestionObject("foo", inputItems = listOf(StringTextInputItemObject(), StringTextInputItemObject()), resultIdentifier = "bar")
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
         assertEquals(original.answerType, result.answerType)
     }
 
@@ -217,18 +193,10 @@ class QuestionTest : NavigationTestHelper() {
      */
 
     @Test
-    fun testSimpleQuestion_Result_NullResultId() {
+    fun testSimpleQuestion_Result() {
         val original = SimpleQuestionObject("foo", inputItem = StringTextInputItemObject())
         val result = original.createResult()
         assertEquals("foo", result.identifier)
-        assertEquals(original.answerType, result.answerType)
-    }
-
-    @Test
-    fun testSimpleQuestion_Result_WithResultId() {
-        val original = SimpleQuestionObject("foo", inputItem = StringTextInputItemObject(), resultIdentifier = "bar")
-        val result = original.createResult()
-        assertEquals("bar", result.identifier)
         assertEquals(original.answerType, result.answerType)
     }
 


### PR DESCRIPTION
Realized when refactoring SageResearch-iOS to have the navigation and identifiers match the Kotlin model, that the *only* place where the mapping is `identifier != resultIdentifier` is the top level Assessment where the schema identifier may be different. While historically we have *not* had different tasks map to the same schema, this cannot be said for how our partners are using the framework. As such, it made more sense to move to explicitly defining the schema identifier but only
for the `Assessment`.

Toward that end, I removed `resultIdentifier` from the `ResultMapElement` and added `schemaIdentifier` to the `Assessment`. This is a non-deprecated breaking change that MTB will need to adopt if they are going to map multiple schemas to the same assessment.