### PR TITLE
Fix assessment viewmodel lifecycle

### DIFF
--- a/androidApp/src/main/kotlin/AppModule.kt
+++ b/androidApp/src/main/kotlin/AppModule.kt
@@ -2,6 +2,10 @@ package org.sagebionetworks.assessmentmodel.sampleapp
 
 import org.koin.dsl.module
 import org.sagebionetworks.assessmentmodel.AssessmentRegistryProvider
+import org.sagebionetworks.assessmentmodel.BranchNode
+import org.sagebionetworks.assessmentmodel.navigation.CustomNodeStateProvider
+import org.sagebionetworks.assessmentmodel.presentation.AssessmentFragment
+import org.sagebionetworks.assessmentmodel.presentation.AssessmentFragmentProvider
 import org.sagebionetworks.assessmentmodel.resourcemanagement.FileLoader
 import org.sagebionetworks.assessmentmodel.serialization.EmbeddedJsonAssessmentRegistryProvider
 import org.sagebionetworks.assessmentmodel.serialization.FileLoaderAndroid
@@ -11,5 +15,17 @@ val appModule = module {
     single<AssessmentRegistryProvider> { EmbeddedJsonAssessmentRegistryProvider(get(), "embedded_assessment_registry") }
 
     factory<FileLoader> {FileLoaderAndroid(get())}
+
+    single<CustomNodeStateProvider?> {
+        object : CustomNodeStateProvider {
+
+        }}
+
+    single<AssessmentFragmentProvider?> {
+        object : AssessmentFragmentProvider {
+            override fun fragmentFor(branchNode: BranchNode): AssessmentFragment {
+                return AssessmentFragment()
+            }
+        }}
 
 }

--- a/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentFragment.kt
+++ b/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentFragment.kt
@@ -69,7 +69,7 @@ open class AssessmentFragment : Fragment() {
 
     open fun initViewModel(branchNodeState: BranchNodeState) =
         ViewModelProvider(
-            this, AssessmentViewModelFactory()
+            requireActivity(), AssessmentViewModelFactory()
                 .create(branchNodeState)
         ).get(AssessmentViewModel::class.java)
 

--- a/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentFragment.kt
+++ b/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentFragment.kt
@@ -63,17 +63,24 @@ open class AssessmentFragment : Fragment() {
 
         viewModel.currentNodeStateLiveData
             .observe(this.viewLifecycleOwner, Observer<AssessmentViewModel.ShowNodeState>
-            { showNodeState -> this.showStep(showNodeState) })
+            { showNodeState ->
+                // If the event has already been handled, then fragment is being restored from a
+                // configuration change and the step fragment will be automatically restored for us.
+                if (!showNodeState.hasBeenHandled) {
+                    this.showStep(showNodeState)
+                }
+            })
         viewModel.start()
     }
 
     open fun initViewModel(branchNodeState: BranchNodeState) =
         ViewModelProvider(
-            requireActivity(), AssessmentViewModelFactory()
+            this, AssessmentViewModelFactory()
                 .create(branchNodeState)
         ).get(AssessmentViewModel::class.java)
 
     open fun showStep(showNodeState: AssessmentViewModel.ShowNodeState) {
+        showNodeState.hasBeenHandled = true
         if (NavigationPoint.Direction.Exit == showNodeState.direction) {
             val resultIntent = Intent()
             resultIntent.putExtra(

--- a/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentViewModel.kt
+++ b/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/AssessmentViewModel.kt
@@ -13,15 +13,13 @@ open class AssessmentViewModel(
     val assessmentNodeState: BranchNodeState
 ) : ViewModel(), NodeUIController {
 
-
-    private var isStarted = false
     protected val currentNodeStateMutableLiveData: MutableLiveData<ShowNodeState> = MutableLiveData()
     val currentNodeStateLiveData: LiveData<ShowNodeState> = currentNodeStateMutableLiveData
 
     fun start() {
-        if (!isStarted) {
-            isStarted = true
-            assessmentNodeState.nodeUIController = this
+        assessmentNodeState.nodeUIController = this
+        if (assessmentNodeState.currentChild == null) {
+            //If we don't yet have a current child then we need to start this assessment
             goForward()
         }
     }
@@ -78,7 +76,8 @@ open class AssessmentViewModel(
         val nodeState: NodeState,
         val direction: NavigationPoint.Direction,
         val requestedPermissions: Set<PermissionInfo>?,
-        val asyncActionNavigations: Set<AsyncActionNavigation>?
+        val asyncActionNavigations: Set<AsyncActionNavigation>?,
+        var hasBeenHandled: Boolean = false
     )
 
 }

--- a/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/RootAssessmentViewModel.kt
+++ b/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/RootAssessmentViewModel.kt
@@ -12,6 +12,7 @@ open class RootAssessmentViewModel(
     val nodeStateProvider: CustomNodeStateProvider? = null
 ) : ViewModel(), RootNodeController {
 
+    var hasHandledLoad = false
     var assessmentNodeState: BranchNodeState? = null
     protected val assessmentLoadedMutableLiveData: MutableLiveData<BranchNodeState> = MutableLiveData()
     val assessmentLoadedLiveData: LiveData<BranchNodeState> = assessmentLoadedMutableLiveData


### PR DESCRIPTION
Now that assessments can be run as part of another assessment, their ViewModel needs to be tied to the Activity lifecycle.