### PR TITLE
Add date utils for going from kotlinx.datetime.Instant to ISO_8601 date string.

### DIFF
--- a/assessmentModel/build.gradle.kts
+++ b/assessmentModel/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
       commonMain {
          dependencies {
              api ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1")
+             api("org.jetbrains.kotlinx:kotlinx-datetime:0.1.1")
          }
       }
       commonTest {

--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -33,8 +33,6 @@ actual object UUIDGenerator {
 }
 
 actual object DateUtils {
-    
-    actual fun currentYear(): Int = ZonedDateTime.now().year
 
     private var timeZoneOverride: TimeZone? = null
 

--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -3,6 +3,7 @@ package org.sagebionetworks.assessmentmodel
 import android.os.Build
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaZoneId
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -36,15 +37,36 @@ actual object DateUtils {
     
     actual fun currentYear(): Int = ZonedDateTime.now().year
 
-    actual fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone): String {
+    private var timeZoneOverride: TimeZone? = null
+
+    /**
+     * For testing purposes
+     */
+    internal actual fun timeZoneOverride(timeZone: TimeZone) {
+        timeZoneOverride = timeZone
+    }
+
+    private val iso8601Formatter: DateTimeFormatter = {
+        //Would prefer to use DateTimeFormatter.ISO_OFFSET_DATE_TIME, but it is inconsistent with iOS.
+        //  ISO_OFFSET_DATE_TIME has a variable number of digits for fractional seconds.
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ", Locale.US)
+    }()
+
+    /**
+     * Create an ISO_8601 formatted string from the specified [Instant].
+     * The format is "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" which looks like:
+     * "2021-03-23T14:58:54.106-07:00"
+     */
+    actual fun bridgeIsoDateTimeString(instant: Instant): String {
         val jtInstant = java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds())
-        val zoneId = ZoneId.of(timeZone.id)
-        return ZonedDateTime.ofInstant(jtInstant, zoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val zoneId = timeZoneOverride?.toJavaZoneId() ?: TimeZone.currentSystemDefault().toJavaZoneId()
+        return ZonedDateTime.ofInstant(jtInstant, zoneId).format(iso8601Formatter)
     }
 
     actual fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant {
-        val dateTime = ZonedDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dateString))
+        val dateTime = ZonedDateTime.from(iso8601Formatter.parse(dateString))
         val jtInstant = dateTime.toInstant()
         return Instant.fromEpochMilliseconds(jtInstant.toEpochMilli())
     }
+
 }

--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -2,6 +2,7 @@ package org.sagebionetworks.assessmentmodel
 
 import android.os.Build
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -35,9 +36,10 @@ actual object DateUtils {
     
     actual fun currentYear(): Int = ZonedDateTime.now().year
 
-    actual fun bridgeIsoDateTimeString(instant: Instant): String {
+    actual fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone): String {
         val jtInstant = java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds())
-        return ZonedDateTime.ofInstant(jtInstant, ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val zoneId = ZoneId.of(timeZone.id)
+        return ZonedDateTime.ofInstant(jtInstant, zoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     }
 
     actual fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant {

--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -1,6 +1,8 @@
 package org.sagebionetworks.assessmentmodel
 
 import android.os.Build
+import kotlinx.datetime.Instant
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -28,8 +30,19 @@ actual object UUIDGenerator {
     actual fun uuidString() : String = UUID.randomUUID().toString()
 }
 
-actual object DateGenerator {
-    actual fun nowString(): String = ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+actual object DateUtils {
+    actual fun nowString(): String = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     
     actual fun currentYear(): Int = ZonedDateTime.now().year
+
+    actual fun bridgeIsoDateTimeString(instant: Instant): String {
+        val jtInstant = java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds())
+        return ZonedDateTime.ofInstant(jtInstant, ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    }
+
+    actual fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant {
+        val dateTime = ZonedDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(dateString))
+        val jtInstant = dateTime.toInstant()
+        return Instant.fromEpochMilliseconds(jtInstant.toEpochMilli())
+    }
 }

--- a/assessmentModel/src/androidLibMain/kotlin/android.kt
+++ b/assessmentModel/src/androidLibMain/kotlin/android.kt
@@ -33,7 +33,6 @@ actual object UUIDGenerator {
 }
 
 actual object DateUtils {
-    actual fun nowString(): String = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     
     actual fun currentYear(): Int = ZonedDateTime.now().year
 
@@ -49,7 +48,7 @@ actual object DateUtils {
     private val iso8601Formatter: DateTimeFormatter = {
         //Would prefer to use DateTimeFormatter.ISO_OFFSET_DATE_TIME, but it is inconsistent with iOS.
         //  ISO_OFFSET_DATE_TIME has a variable number of digits for fractional seconds.
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ", Locale.US)
+        DateTimeFormatter.ofPattern(DateConstants.BRIDGE_ISO_DATE_TIME_FORMAT, Locale.US)
     }()
 
     /**

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -1,5 +1,6 @@
 package org.sagebionetworks.assessmentmodel
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import org.sagebionetworks.assessmentmodel.navigation.NavigationPoint
@@ -25,12 +26,12 @@ interface Result {
     /**
      * The start date timestamp for the result.
      */
-    var startDateString: String
+    var startDateTime: Instant
 
     /**
      * The end date timestamp for the result.
      */
-    var endDateString: String?
+    var endDateTime: Instant?
 }
 
 fun MutableSet<Result>.copyResults() = map { it.copyResult() }.toMutableSet()

--- a/assessmentModel/src/commonMain/kotlin/common.kt
+++ b/assessmentModel/src/commonMain/kotlin/common.kt
@@ -1,6 +1,7 @@
 package org.sagebionetworks.assessmentmodel
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
 
 expect class Platform() {
     val platform: String
@@ -16,7 +17,7 @@ expect object DateUtils {
      * The format is "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" which looks like:
      * "2021-03-23T14:58:54.106-07:00"
      */
-    fun bridgeIsoDateTimeString(instant: Instant): String
+    fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone = TimeZone.currentSystemDefault()): String
 
     /**
      * Parse an ISO_8601 string of format "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" into an [Instant].

--- a/assessmentModel/src/commonMain/kotlin/common.kt
+++ b/assessmentModel/src/commonMain/kotlin/common.kt
@@ -12,12 +12,18 @@ expect object UUIDGenerator {
 }
 
 expect object DateUtils {
+
+    /**
+     * For testing purposes
+     */
+    internal fun timeZoneOverride(timeZone: TimeZone)
+
     /**
      * Create an ISO_8601 formatted string from the specified [Instant].
      * The format is "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" which looks like:
      * "2021-03-23T14:58:54.106-07:00"
      */
-    fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone = TimeZone.currentSystemDefault()): String
+    fun bridgeIsoDateTimeString(instant: Instant): String
 
     /**
      * Parse an ISO_8601 string of format "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" into an [Instant].

--- a/assessmentModel/src/commonMain/kotlin/common.kt
+++ b/assessmentModel/src/commonMain/kotlin/common.kt
@@ -11,6 +11,10 @@ expect object UUIDGenerator {
     fun uuidString(): String
 }
 
+object DateConstants {
+    const val BRIDGE_ISO_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+}
+
 expect object DateUtils {
 
     /**
@@ -29,7 +33,7 @@ expect object DateUtils {
      * Parse an ISO_8601 string of format "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" into an [Instant].
      */
     fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant
-    fun nowString(): String
+
     fun currentYear(): Int
 }
 

--- a/assessmentModel/src/commonMain/kotlin/common.kt
+++ b/assessmentModel/src/commonMain/kotlin/common.kt
@@ -1,5 +1,7 @@
 package org.sagebionetworks.assessmentmodel
 
+import kotlinx.datetime.Instant
+
 expect class Platform() {
     val platform: String
 }
@@ -8,7 +10,18 @@ expect object UUIDGenerator {
     fun uuidString(): String
 }
 
-expect object DateGenerator {
+expect object DateUtils {
+    /**
+     * Create an ISO_8601 formatted string from the specified [Instant].
+     * The format is "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" which looks like:
+     * "2021-03-23T14:58:54.106-07:00"
+     */
+    fun bridgeIsoDateTimeString(instant: Instant): String
+
+    /**
+     * Parse an ISO_8601 string of format "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" into an [Instant].
+     */
+    fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant
     fun nowString(): String
     fun currentYear(): Int
 }

--- a/assessmentModel/src/commonMain/kotlin/common.kt
+++ b/assessmentModel/src/commonMain/kotlin/common.kt
@@ -34,7 +34,6 @@ expect object DateUtils {
      */
     fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant
 
-    fun currentYear(): Int
 }
 
 expect class Product {

--- a/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
@@ -246,7 +246,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
         val next = getNextNode(direction) ?: return
         unionNavigationSets(next, requestedPermissions, asyncActionNavigations)
         // Before moving to the next node (or ending the task), mark the end data for the current node.
-        currentChild?.currentResult?.endDateString = DateGenerator.nowString()
+        currentChild?.currentResult?.endDateString = DateUtils.nowString()
         if (next.node != null) {
             // Go to next node if it is not null.
             moveTo(next)
@@ -276,7 +276,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
             getLeafNodeState(navigationPoint)?.let { nodeState ->
                 currentChild = nodeState
                 // Mark the start/end timestamps before displaying the node.
-                nodeState.currentResult.startDateString = DateGenerator.nowString()
+                nodeState.currentResult.startDateString = DateUtils.nowString()
                 nodeState.currentResult.endDateString = null
                 // Check if the "ready-to-save" state should be changed.
                 if (navigator.isCompleted(nodeState.node, currentResult)) {
@@ -353,7 +353,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
     private fun markFinalResultIfNeeded() {
         if (hasMarkedFinalResult) return
         this.hasMarkedFinalResult = true
-        currentResult.endDateString = DateGenerator.nowString()
+        currentResult.endDateString = DateUtils.nowString()
         didMarkFinalResult()
     }
     private var hasMarkedFinalResult = false

--- a/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
+++ b/assessmentModel/src/commonMain/kotlin/navigation/NodeState.kt
@@ -1,5 +1,6 @@
 package org.sagebionetworks.assessmentmodel.navigation
 
+import kotlinx.datetime.Clock
 import org.sagebionetworks.assessmentmodel.*
 import org.sagebionetworks.assessmentmodel.survey.FormStepStateImpl
 import org.sagebionetworks.assessmentmodel.survey.Question
@@ -246,7 +247,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
         val next = getNextNode(direction) ?: return
         unionNavigationSets(next, requestedPermissions, asyncActionNavigations)
         // Before moving to the next node (or ending the task), mark the end data for the current node.
-        currentChild?.currentResult?.endDateString = DateUtils.nowString()
+        currentChild?.currentResult?.endDateTime = Clock.System.now()
         if (next.node != null) {
             // Go to next node if it is not null.
             moveTo(next)
@@ -276,8 +277,8 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
             getLeafNodeState(navigationPoint)?.let { nodeState ->
                 currentChild = nodeState
                 // Mark the start/end timestamps before displaying the node.
-                nodeState.currentResult.startDateString = DateUtils.nowString()
-                nodeState.currentResult.endDateString = null
+                nodeState.currentResult.startDateTime = Clock.System.now()
+                nodeState.currentResult.endDateTime = null
                 // Check if the "ready-to-save" state should be changed.
                 if (navigator.isCompleted(nodeState.node, currentResult)) {
                     callUpReadyToSaveChain()
@@ -353,7 +354,7 @@ open class BranchNodeStateImpl(override val node: BranchNode, final override val
     private fun markFinalResultIfNeeded() {
         if (hasMarkedFinalResult) return
         this.hasMarkedFinalResult = true
-        currentResult.endDateString = DateUtils.nowString()
+        currentResult.endDateTime = Clock.System.now()
         didMarkFinalResult()
     }
     private var hasMarkedFinalResult = false

--- a/assessmentModel/src/commonMain/kotlin/serialization/NumberFormatOptions.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/NumberFormatOptions.kt
@@ -1,5 +1,8 @@
 package org.sagebionetworks.assessmentmodel.serialization
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -103,7 +106,7 @@ data class YearFormatOptions(var allowFuture: Boolean = true,
     override val maximumValue: Int?
         get() = maximumYear ?: if (allowFuture) null else _currentYear
 
-    private val _currentYear = DateUtils.currentYear()
+    private val _currentYear =  Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year
 
     override val stepInterval: Int?
         get() = 1

--- a/assessmentModel/src/commonMain/kotlin/serialization/NumberFormatOptions.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/NumberFormatOptions.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import org.sagebionetworks.assessmentmodel.DateGenerator
+import org.sagebionetworks.assessmentmodel.DateUtils
 import org.sagebionetworks.assessmentmodel.StringEnum
 import org.sagebionetworks.assessmentmodel.matching
 import org.sagebionetworks.assessmentmodel.survey.*
@@ -103,7 +103,7 @@ data class YearFormatOptions(var allowFuture: Boolean = true,
     override val maximumValue: Int?
         get() = maximumYear ?: if (allowFuture) null else _currentYear
 
-    private val _currentYear = DateGenerator.currentYear()
+    private val _currentYear = DateUtils.currentYear()
 
     override val stepInterval: Int?
         get() = 1

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -1,9 +1,11 @@
 package org.sagebionetworks.assessmentmodel.serialization
 
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -32,9 +34,11 @@ data class AnswerResultObject(override val identifier: String,
                               @SerialName("value")
                               override var jsonValue: JsonElement? = null,
                               @SerialName("startDate")
-                              override var startDateString: String = DateUtils.nowString(),
+                              @Serializable(with = InstantSerializer::class)
+                              override var startDateTime: Instant = Clock.System.now(),
                               @SerialName("endDate")
-                              override var endDateString: String? = null) : AnswerResult {
+                              @Serializable(with = InstantSerializer::class)
+                              override var endDateTime: Instant? = null) : AnswerResult {
     override fun copyResult(identifier: String): AnswerResult = this.copy(identifier = identifier)
 }
 
@@ -51,9 +55,11 @@ data class AssessmentResultObject(override val identifier: String,
                                   @SerialName("taskRunUUID")
                                   override var runUUIDString: String = UUIDGenerator.uuidString(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateUtils.nowString(),
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var startDateTime: Instant = Clock.System.now(),
                                   @SerialName("endDate")
-                                  override var endDateString: String? = null,
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var endDateTime: Instant? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null)
@@ -68,9 +74,11 @@ data class AssessmentResultObject(override val identifier: String,
 @SerialName("base")
 data class ResultObject(override val identifier: String,
                         @SerialName("startDate")
-                        override var startDateString: String = DateUtils.nowString(),
+                        @Serializable(with = InstantSerializer::class)
+                        override var startDateTime: Instant = Clock.System.now(),
                         @SerialName("endDate")
-                        override var endDateString: String? = null,
+                        @Serializable(with = InstantSerializer::class)
+                        override var endDateTime: Instant? = null,
                         @SerialName("skipToIdentifier")
                         override var nextNodeIdentifier: String? = null) : Result, ResultNavigationRule {
     override fun copyResult(identifier: String): Result = this.copy(identifier = identifier)
@@ -81,9 +89,11 @@ data class ResultObject(override val identifier: String,
 data class CollectionResultObject(override val identifier: String,
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateUtils.nowString(),
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var startDateTime: Instant = Clock.System.now(),
                                   @SerialName("endDate")
-                                  override var endDateString: String? = null,
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var endDateTime: Instant? = null,
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : CollectionResult, ResultNavigationRule {
     override fun copyResult(identifier: String): CollectionResult = this.copy(
@@ -99,9 +109,11 @@ data class BranchNodeResultObject(override val identifier: String,
                                   @SerialName("asyncResults")
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateUtils.nowString(),
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var startDateTime: Instant = Clock.System.now(),
                                   @SerialName("endDate")
-                                  override var endDateString: String? = null,
+                                  @Serializable(with = InstantSerializer::class)
+                                  override var endDateTime: Instant? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
                                   @SerialName("skipToIdentifier")
                                   override var nextNodeIdentifier: String? = null) : BranchNodeResult, ResultNavigationRule {

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -1,7 +1,14 @@
 package org.sagebionetworks.assessmentmodel.serialization
 
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.modules.*
 import org.sagebionetworks.assessmentmodel.*
@@ -25,7 +32,7 @@ data class AnswerResultObject(override val identifier: String,
                               @SerialName("value")
                               override var jsonValue: JsonElement? = null,
                               @SerialName("startDate")
-                              override var startDateString: String = DateGenerator.nowString(),
+                              override var startDateString: String = DateUtils.nowString(),
                               @SerialName("endDate")
                               override var endDateString: String? = null) : AnswerResult {
     override fun copyResult(identifier: String): AnswerResult = this.copy(identifier = identifier)
@@ -44,7 +51,7 @@ data class AssessmentResultObject(override val identifier: String,
                                   @SerialName("taskRunUUID")
                                   override var runUUIDString: String = UUIDGenerator.uuidString(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateGenerator.nowString(),
+                                  override var startDateString: String = DateUtils.nowString(),
                                   @SerialName("endDate")
                                   override var endDateString: String? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
@@ -61,7 +68,7 @@ data class AssessmentResultObject(override val identifier: String,
 @SerialName("base")
 data class ResultObject(override val identifier: String,
                         @SerialName("startDate")
-                        override var startDateString: String = DateGenerator.nowString(),
+                        override var startDateString: String = DateUtils.nowString(),
                         @SerialName("endDate")
                         override var endDateString: String? = null,
                         @SerialName("skipToIdentifier")
@@ -74,7 +81,7 @@ data class ResultObject(override val identifier: String,
 data class CollectionResultObject(override val identifier: String,
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateGenerator.nowString(),
+                                  override var startDateString: String = DateUtils.nowString(),
                                   @SerialName("endDate")
                                   override var endDateString: String? = null,
                                   @SerialName("skipToIdentifier")
@@ -92,7 +99,7 @@ data class BranchNodeResultObject(override val identifier: String,
                                   @SerialName("asyncResults")
                                   override var inputResults: MutableSet<Result> = mutableSetOf(),
                                   @SerialName("startDate")
-                                  override var startDateString: String = DateGenerator.nowString(),
+                                  override var startDateString: String = DateUtils.nowString(),
                                   @SerialName("endDate")
                                   override var endDateString: String? = null,
                                   override val path: MutableList<PathMarker> = mutableListOf(),
@@ -102,6 +109,20 @@ data class BranchNodeResultObject(override val identifier: String,
             identifier = identifier,
             pathHistoryResults = pathHistoryResults.copyResults(),
             inputResults = inputResults.copyResults())
+}
+
+//Could use this if we want to switch "startDate" and "endDate" to being an Instant
+object InstantSerializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
+
+    override fun serialize(output: Encoder, obj: Instant) {
+        output.encodeString(DateUtils.bridgeIsoDateTimeString(obj))
+    }
+
+    override fun deserialize(input: Decoder): Instant {
+        return DateUtils.instantFromBridgeIsoDateTimeString(input.decodeString())
+    }
 }
 
 

--- a/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
@@ -1,5 +1,7 @@
 package org.sagebionetworks.assessmentmodel.navigation
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import org.sagebionetworks.assessmentmodel.*
 import org.sagebionetworks.assessmentmodel.serialization.*
 import org.sagebionetworks.assessmentmodel.survey.ReservedNavigationIdentifier
@@ -955,8 +957,8 @@ open class NavigationTestHelper {
         // TODO: syoung 06/16/2020 Once timestamp generation is implemented for Android (which is the platform used for test)
         // then add checks that the dates are being updated properly to mark begin/end of steps.
 
-        override var startDateString: String = DateUtils.nowString()
-        override var endDateString: String? = null
+        override var startDateTime: Instant = Clock.System.now()
+        override var endDateTime: Instant? = null
 
         override fun copyResult(identifier: String): Result = copy(identifier = identifier)
     }

--- a/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/navigation/NodeNavigatorTest.kt
@@ -955,7 +955,7 @@ open class NavigationTestHelper {
         // TODO: syoung 06/16/2020 Once timestamp generation is implemented for Android (which is the platform used for test)
         // then add checks that the dates are being updated properly to mark begin/end of steps.
 
-        override var startDateString: String = DateGenerator.nowString()
+        override var startDateString: String = DateUtils.nowString()
         override var endDateString: String? = null
 
         override fun copyResult(identifier: String): Result = copy(identifier = identifier)

--- a/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
@@ -1,14 +1,14 @@
 package org.sagebionetworks.assessmentmodel.serialization
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.ZoneOffset
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
+import org.sagebionetworks.assessmentmodel.DateUtils
 import org.sagebionetworks.assessmentmodel.Result
 import org.sagebionetworks.assessmentmodel.survey.AnswerType
 import org.sagebionetworks.assessmentmodel.survey.BaseType
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
+import kotlin.test.*
 
 open class ResultTest {
 
@@ -17,66 +17,71 @@ open class ResultTest {
 
     private val jsonCoder = Serialization.JsonCoder.default
 
+    @BeforeTest
+    fun setUp() {
+        DateUtils.timeZoneOverride(kotlinx.datetime.TimeZone.of("UTC-03:00"))
+    }
+
     /**
      * Collection-type results
      */
     @Test
     fun testParentNodeResult() {
-        val result1 = ResultObject("result1", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val result2 = ResultObject("result2", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val resultA = ResultObject("resultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val resultB = ResultObject("resultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val asyncResultA = ResultObject("asyncResultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val asyncResultB = ResultObject("asyncResultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val result1 = ResultObject("result1", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val result2 = ResultObject("result2", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val resultA = ResultObject("resultA", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val resultB = ResultObject("resultB", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val asyncResultA = ResultObject("asyncResultA", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val asyncResultB = ResultObject("asyncResultB", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
         val result3 = BranchNodeResultObject(
             identifier = "result3",
             pathHistoryResults = mutableListOf(resultA, resultB),
             inputResults = mutableSetOf(asyncResultA, asyncResultB),
-            startDateString = "2020-01-21T12:00:00.000+7000",
-            endDateString = "2020-01-21T12:05:00.000+7000"
+            startDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),
+            endDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")
         )
         val result4 = CollectionResultObject(
             identifier = "result4",
             inputResults = mutableSetOf(asyncResultA, asyncResultB),
-            startDateString = "2020-01-21T12:00:00.000+7000",
-            endDateString = "2020-01-21T12:05:00.000+7000"
+            startDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),
+            endDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")
         )
         val original = BranchNodeResultObject(
             identifier = "testResult",
             pathHistoryResults = mutableListOf(result1, result2, result3, result4),
-            startDateString = "2020-01-21T12:00:00.000+7000",
-            endDateString = "2020-01-21T12:05:00.000+7000"
+            startDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),
+            endDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")
         )
         val inputString = """
             {
                 "identifier": "testResult",
-                "startDate": "2020-01-21T12:00:00.000+7000",
-                "endDate": "2020-01-21T12:05:00.000+7000",
+                "startDate": "2020-01-21T12:00:00.000-03:00",
+                "endDate": "2020-01-21T12:05:00.000-03:00",
                 "stepHistory": [
-                    {"identifier": "result1","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                    {"identifier": "result2","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
+                    {"identifier": "result1","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                    {"identifier": "result2","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
                     {
                         "identifier": "result3",
                         "type": "section",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "stepHistory": [
-                            {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                            {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                            {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                            {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"}
                         ],
                         "asyncResults": [
-                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"}
                         ]
                     },
                     {
                         "identifier": "result4",
                         "type": "collection",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "inputResults": [
-                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                            {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                            {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"}
                         ]
                     }
                 ]
@@ -108,31 +113,31 @@ open class ResultTest {
 
     @Test
     fun testAssessmentResult() {
-        val resultA = ResultObject("resultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val resultB = ResultObject("resultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val asyncResultA = ResultObject("asyncResultA", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
-        val asyncResultB = ResultObject("asyncResultB", "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000")
+        val resultA = ResultObject("resultA", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val resultB = ResultObject("resultB", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val asyncResultA = ResultObject("asyncResultA", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
+        val asyncResultB = ResultObject("asyncResultB", DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00"))
 
         val original = AssessmentResultObject(identifier = "testResult",
                 pathHistoryResults = mutableListOf(resultA, resultB),
                 inputResults = mutableSetOf(asyncResultA, asyncResultB),
                 runUUIDString = "4cb0580-3cdb-11ea-b77f-2e728ce88125",
-                startDateString = "2020-01-21T12:00:00.000+7000",
-                endDateString = "2020-01-21T12:05:00.000+7000"
+                startDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),
+                endDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")
             )
          val inputString = """
             {
                 "identifier": "testResult",
                 "taskRunUUID": "4cb0580-3cdb-11ea-b77f-2e728ce88125",
-                "startDate": "2020-01-21T12:00:00.000+7000",
-                "endDate": "2020-01-21T12:05:00.000+7000",
+                "startDate": "2020-01-21T12:00:00.000-03:00",
+                "endDate": "2020-01-21T12:05:00.000-03:00",
                 "stepHistory": [
-                    {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                    {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                    {"identifier": "resultA","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                    {"identifier": "resultB","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"}
                 ],
                 "asyncResults": [
-                    {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"},
-                    {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000+7000","endDate": "2020-01-21T12:05:00.000+7000"}
+                    {"identifier": "asyncResultA","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"},
+                    {"identifier": "asyncResultB","type": "base","startDate": "2020-01-21T12:00:00.000-03:00","endDate": "2020-01-21T12:05:00.000-03:00"}
                 ]
             }
             """.trimIndent()
@@ -148,8 +153,8 @@ open class ResultTest {
         val jsonWrapper = Json.parseToJsonElement(jsonString).jsonObject
         assertEquals("testResult", jsonWrapper["identifier"]?.jsonPrimitive?.content)
         assertEquals("4cb0580-3cdb-11ea-b77f-2e728ce88125", jsonWrapper["taskRunUUID"]?.jsonPrimitive?.content)
-        assertEquals("2020-01-21T12:00:00.000+7000", jsonWrapper["startDate"]?.jsonPrimitive?.content)
-        assertEquals("2020-01-21T12:05:00.000+7000", jsonWrapper["endDate"]?.jsonPrimitive?.content)
+        assertEquals("2020-01-21T12:00:00.000-03:00", jsonWrapper["startDate"]?.jsonPrimitive?.content)
+        assertEquals("2020-01-21T12:05:00.000-03:00", jsonWrapper["endDate"]?.jsonPrimitive?.content)
         val pathHistory = jsonWrapper["stepHistory"]?.jsonArray
         assertNotNull(pathHistory)
         assertEquals(2, pathHistory.count())
@@ -196,14 +201,14 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Boolean() {
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.BOOLEAN, JsonPrimitive(true), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.BOOLEAN, JsonPrimitive(true), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
-            { "result": 
+            { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "boolean"
                         },
@@ -225,14 +230,14 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Decimal() {
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.DECIMAL, JsonPrimitive(3.2), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.DECIMAL, JsonPrimitive(3.2), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "number"
                         },
@@ -254,14 +259,14 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Int() {
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.INTEGER, JsonPrimitive(3), "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.INTEGER, JsonPrimitive(3), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
             { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "integer"
                         },
@@ -284,14 +289,14 @@ open class ResultTest {
     fun testAnswerResult_Map() {
         val originalValue = JsonObject(mapOf("a" to JsonPrimitive(3.2), "b" to JsonPrimitive("boo")))
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.OBJECT, originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.OBJECT, originalValue, DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "object"
                         },
@@ -314,14 +319,14 @@ open class ResultTest {
     fun testAnswerResult_String() {
         val originalValue = JsonPrimitive("goo")
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.STRING, originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.STRING, originalValue, DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "string"
                         },
@@ -344,14 +349,14 @@ open class ResultTest {
     fun testAnswerResult_DateYearMonth() {
         val originalValue = JsonPrimitive("2020-02")
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.DateTime("yyyy-MM"), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.DateTime("yyyy-MM"), originalValue, DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "dateTime",
                             "codingFormat": "yyyy-MM"
@@ -375,14 +380,14 @@ open class ResultTest {
     fun testAnswerResult_ListInt() {
         val originalValue = JsonArray(listOf(JsonPrimitive(2), JsonPrimitive(5)))
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.Array(BaseType.INTEGER), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.Array(BaseType.INTEGER), originalValue, DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "array",
                             "baseType": "integer"
@@ -406,14 +411,14 @@ open class ResultTest {
     fun testAnswerResult_Measurement() {
         val originalValue = JsonPrimitive(10.2)
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.Measurement("cm"), originalValue, "2020-01-21T12:00:00.000+7000","2020-01-21T12:05:00.000+7000"))
+            AnswerResultObject("foo", AnswerType.Measurement("cm"), originalValue, DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
                         "identifier" : "foo",
                         "type" : "answer",
-                        "startDate": "2020-01-21T12:00:00.000+7000",
-                        "endDate": "2020-01-21T12:05:00.000+7000",
+                        "startDate": "2020-01-21T12:00:00.000-03:00",
+                        "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
                             "type": "measurement",
                             "unit": "cm"
@@ -463,8 +468,8 @@ open class ResultTest {
                 pathHistoryResults = pathHistoryResults,
                 inputResults = inputResults,
                 runUUIDString = "4cb0580-3cdb-11ea-b77f-2e728ce88125",
-                startDateString = "2020-01-21T12:00:00.000+7000",
-                endDateString = "2020-01-21T12:05:00.000+7000"
+                startDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"),
+                endDateTime = DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")
         )
         val copy = original.copyResult()
         assertEquals(original, copy)

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -43,7 +43,6 @@ actual object UUIDGenerator {
 }
 
 actual object DateUtils {
-    actual fun nowString(): String = iso8601Formatter.stringFromDate(NSDate.now)
     
     /**
      * For testing purposes
@@ -54,7 +53,7 @@ actual object DateUtils {
 
     private val iso8601Formatter: NSDateFormatter = {
         val formatter = NSDateFormatter.new()!!
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        formatter.dateFormat = DateConstants.BRIDGE_ISO_DATE_TIME_FORMAT
         formatter.locale = NSLocale.localeWithLocaleIdentifier("en_US_POSIX")
         formatter
     }()

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -58,8 +58,6 @@ actual object DateUtils {
         formatter
     }()
 
-    actual fun currentYear(): Int = NSCalendar(NSISO8601Calendar).component(NSCalendarUnitYear, NSDate.now).toInt()
-
     actual fun bridgeIsoDateTimeString(instant: Instant): String {
         val timeInterval: NSTimeInterval = instant.toEpochMilliseconds() / 1000.0
         val date = NSDate.dateWithTimeIntervalSince1970(timeInterval)

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -69,6 +69,9 @@ actual object DateUtils {
 
     actual fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant {
         val date = iso8601Formatter.dateFromString(dateString)
+        if (date == null) {
+            throw IllegalArgumentException("Unable to parse date string: $dateString")
+        }
         val timeInterval = date!!.timeIntervalSince1970()
         val milliSec = (timeInterval * 1000).toLong()
         return Instant.fromEpochMilliseconds(milliSec)

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -6,6 +6,8 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toNSTimeZone
+import org.sagebionetworks.assessmentmodel.survey.ISO8601Format
 import platform.Foundation.*
 import platform.posix.uname
 import platform.posix.utsname
@@ -42,6 +44,13 @@ actual object UUIDGenerator {
 
 actual object DateUtils {
     actual fun nowString(): String = iso8601Formatter.stringFromDate(NSDate.now)
+    
+    /**
+     * For testing purposes
+     */
+    internal actual fun timeZoneOverride(timeZone: TimeZone) {
+        iso8601Formatter.timeZone = timeZone.toNSTimeZone()
+    }
 
     private val iso8601Formatter: NSDateFormatter = {
         val formatter = NSDateFormatter.new()!!
@@ -52,7 +61,7 @@ actual object DateUtils {
 
     actual fun currentYear(): Int = NSCalendar(NSISO8601Calendar).component(NSCalendarUnitYear, NSDate.now).toInt()
 
-    actual fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone): String {
+    actual fun bridgeIsoDateTimeString(instant: Instant): String {
         val timeInterval: NSTimeInterval = instant.toEpochMilliseconds() / 1000.0
         val date = NSDate.dateWithTimeIntervalSince1970(timeInterval)
         return iso8601Formatter.stringFromDate(date)
@@ -64,4 +73,6 @@ actual object DateUtils {
         val milliSec = (timeInterval * 1000).toLong()
         return Instant.fromEpochMilliseconds(milliSec)
     }
+    
+
 }

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -4,6 +4,7 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
+import kotlinx.datetime.Instant
 import platform.Foundation.*
 import platform.posix.uname
 import platform.posix.utsname
@@ -38,7 +39,7 @@ actual object UUIDGenerator {
     actual fun uuidString(): String = NSUUID.UUID().UUIDString
 }
 
-actual object DateGenerator {
+actual object DateUtils {
     actual fun nowString(): String = iso8601Formatter.stringFromDate(NSDate.now)
 
     private val iso8601Formatter: NSDateFormatter = {
@@ -49,4 +50,17 @@ actual object DateGenerator {
     }()
 
     actual fun currentYear(): Int = NSCalendar(NSISO8601Calendar).component(NSCalendarUnitYear, NSDate.now).toInt()
+
+    actual fun bridgeIsoDateTimeString(instant: Instant): String {
+        val timeInterval: NSTimeInterval = instant.toEpochMilliseconds() / 1000.0
+        val date = NSDate.dateWithTimeIntervalSince1970(timeInterval)
+        return iso8601Formatter.stringFromDate(date)
+    }
+
+    actual fun instantFromBridgeIsoDateTimeString(dateString: String) : Instant {
+        val date = iso8601Formatter.dateFromString(dateString)
+        val timeInterval = date!!.timeIntervalSince1970()
+        val milliSec = (timeInterval * 1000).toLong()
+        return Instant.fromEpochMilliseconds(milliSec)
+    }
 }

--- a/assessmentModel/src/iosMain/kotlin/ios.kt
+++ b/assessmentModel/src/iosMain/kotlin/ios.kt
@@ -5,6 +5,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toKString
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
 import platform.Foundation.*
 import platform.posix.uname
 import platform.posix.utsname
@@ -51,7 +52,7 @@ actual object DateUtils {
 
     actual fun currentYear(): Int = NSCalendar(NSISO8601Calendar).component(NSCalendarUnitYear, NSDate.now).toInt()
 
-    actual fun bridgeIsoDateTimeString(instant: Instant): String {
+    actual fun bridgeIsoDateTimeString(instant: Instant, timeZone: TimeZone): String {
         val timeInterval: NSTimeInterval = instant.toEpochMilliseconds() / 1000.0
         val date = NSDate.dateWithTimeIntervalSince1970(timeInterval)
         return iso8601Formatter.stringFromDate(date)


### PR DESCRIPTION
This adds utility methods for going back and forth between a kotlinx.datetime.Instant and the ISO_8601 date string format expected by bridge.  As there currently isn't a way to do this with the kotlinx.datetime library, the implementations are platform specific. The library does have Instance, which is crossplatform and could be used for the in memory representation of "startDate" and "endDate" in results. Doing this would use the InstantSerializer in Results.kt

This is not ready to be merged as it still needs tests, and we should decide if it makes sense to use Instant for startDate and endDate in results. The MTB team is already using Instant for their measures.