### PR TITLE
Add “permission” step type for use in onboarding

### DIFF
--- a/assessmentModel/src/commonMain/kotlin/PermissionInfo.kt
+++ b/assessmentModel/src/commonMain/kotlin/PermissionInfo.kt
@@ -78,6 +78,8 @@ sealed class PermissionType() : StringEnum {
         object Microphone : Standard("microphone")
         object Motion : Standard("motion")
         object PhotoLibrary : Standard("photoLibrary")
+        object LocationWhenInUse : Standard("locationWhenInUse")
+        object Notifications : Standard("notifications")
 
         companion object : StringEnumCompanion<Standard> {
             override fun values(): Array<Standard>

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -35,6 +35,7 @@ val nodeSerializersModule = SerializersModule {
         subclass(InstructionStepObject::class)
         subclass(MultipleInputQuestionObject::class)
         subclass(OverviewStepObject::class)
+        subclass(PermissionStepObject::class)
         subclass(ResultSummaryStepObject::class)
         subclass(SimpleQuestionObject::class)
         subclass(SectionObject::class)
@@ -242,6 +243,23 @@ data class InstructionStepObject(
      override var imageInfo: ImageInfo? = null,
      override var fullInstructionsOnly: Boolean = false
 ) : StepObject(), InstructionStep
+
+@Serializable
+@SerialName("permission")
+data class PermissionStepObject(
+        override val identifier: String,
+        override val permissionType: PermissionType,
+        @SerialName("image")
+        override var imageInfo: ImageInfo? = null,
+        override val optional: Boolean = true,
+        override val requiresBackground: Boolean = false,
+        override val reason: String? = null,
+        override val restrictedMessage: String? = null,
+        override val deniedMessage: String? = null
+) : StepObject(), PermissionStep, PermissionInfo {
+    override val permissions: List<PermissionInfo>
+        get() = listOf(this)
+}
 
 @Serializable
 @SerialName("overview")


### PR DESCRIPTION
Misses this one (or maybe didn't add it originally b/c we were only using the overview step at the time - who knows). Anyway, it's a single permission per step ("screen") that's intended to be used to explain the permissions that the app or assessment may ask for.